### PR TITLE
Add Dependabot to Dependency Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A curated list of awesome companies that offer their tools and services for free
 
 ## Dependency Management
 
+- [Dependabot](https://dependabot.com/) - Automated dependency updates for Ruby, Python, JavaScript and PHP.
 - [Dependency CI](https://dependencyci.com/) - Continuous dependency testing.
 - [deppbot](https://www.deppbot.com/) - Automated security and dependency updates.
 - [gemnasium](https://gemnasium.com/) - Automated dependency management.


### PR DESCRIPTION
Adds [Dependabot](https://dependabot.com) to the list of dependency management tools free for open source

- [x] Your submissions are formatted according to the guidelines: ``[Company Name](link) `tag` - description``
- [x] Your additions are ordered alphabetically.
- [x] Your additions are commercial software that offer their services for free to Open Source projects.
- [x] Your additions contain any relevant tags: `requires-approval`
- [x] You have searched the repository for any relevant issues or PRs.
- [x] Any category you are creating has the minimum requirement of 2 items.
