### PR TITLE
Added exception reporting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ A curated list of awesome companies that offer their tools and services for free
 - [VersionEye](https://www.versioneye.com/) - Notification system for software packages.
 - [WhiteSource](https://www.whitesourcesoftware.com/) - Open source security and license management.
 
+## Exception Reporting
+
+- [BugSnag](https://www.bugsnag.com/) `requires-approval` - Exception tracking and reporting.
+- [Honeybadger](https://www.honeybadger.io) `requires-approval` `non-commercial` - Exception reporting and uptime monitoring.
+
 ## Package Management
 
 - [MyGet](https://myget.org/) `requires-approval` - NuGet, npm, Bower, Maven, and Vsix package hosting.
@@ -83,7 +88,6 @@ A curated list of awesome companies that offer their tools and services for free
 
 ## Monitoring
 
-- [BugSnag](https://www.bugsnag.com/) `requires-approval` - Application error tracking and reporting.
 - [Check my Website](https://checkmy.ws/) `requires-approval` - Automated website monitoring.
 - [DNS Spy](https://dnsspy.io/) `requires-approval` - DNS monitoring.
 - [Honeybadger](https://www.honeybadger.io/) `requires-approval` - Exception and uptime monitoring for Ruby.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A curated list of awesome companies that offer their tools and services for free
 
 ## Monitoring
 
+- [BugSnag](https://www.bugsnag.com/) `requires-approval` - Application error tracking and reporting.
 - [Check my Website](https://checkmy.ws/) `requires-approval` - Automated website monitoring.
 - [DNS Spy](https://dnsspy.io/) `requires-approval` - DNS monitoring.
 - [Honeybadger](https://www.honeybadger.io/) `requires-approval` - Exception and uptime monitoring for Ruby.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A curated list of awesome companies that offer their tools and services for free
 ## Exception Reporting
 
 - [BugSnag](https://www.bugsnag.com/) `requires-approval` - Exception tracking and reporting.
-- [Honeybadger](https://www.honeybadger.io) `requires-approval` `non-commercial` - Exception reporting and uptime monitoring.
+- [Honeybadger](https://www.honeybadger.io) `requires-approval` `non-commercial` - Exception and uptime monitoring for Ruby.
 
 ## Package Management
 
@@ -90,7 +90,6 @@ A curated list of awesome companies that offer their tools and services for free
 
 - [Check my Website](https://checkmy.ws/) `requires-approval` - Automated website monitoring.
 - [DNS Spy](https://dnsspy.io/) `requires-approval` - DNS monitoring.
-- [Honeybadger](https://www.honeybadger.io/) `requires-approval` - Exception and uptime monitoring for Ruby.
 
 ## Localization
 
@@ -130,3 +129,5 @@ Please see the [contributor guidelines](.github/CONTRIBUTING.md) and [code of co
 ## Tags
 
 While many companies use the public repositories feature of GitHub, Bitbucket, and GitLab to determine the Open Source status of a project, there are others who require more verification. These companies have been marked with a `requires-approval` tag, indicating that an application process is required to take advantage of their Open Source benefits.
+
+Some companies make their products available for open source, but only for non-commercial projects. These companies have been marked with a `non-commercial` tag.


### PR DESCRIPTION
Honeybadger is free for non-commercial OSS projects, so I added that as a tag. It might not be necessary, I can remove it no problem.