### PR TITLE
Add Algolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ A curated list of awesome companies that offer their tools and services for free
 
 ## Miscellaneous
 
+- [Algolia](https://www.algolia.com) - Search as a service API
 - [Apiary](https://apiary.io/) `requires-approval` - API design, development, and documentation platform.
 - [Auth0](https://auth0.com/) `requires-approval` - SSO & token-based authentication.
 - [BackHub](https://backhub.co/) - Automated GitHub repository backups.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A curated list of awesome companies that offer their tools and services for free
 
 ## Miscellaneous
 
-- [Algolia](https://www.algolia.com) - Search as a service API
+- [Algolia](https://www.algolia.com) - `requires-approval` Search as a service API
 - [Apiary](https://apiary.io/) `requires-approval` - API design, development, and documentation platform.
 - [Auth0](https://auth0.com/) `requires-approval` - SSO & token-based authentication.
 - [BackHub](https://backhub.co/) - Automated GitHub repository backups.


### PR DESCRIPTION
I was doubting to add `requires-approval` or not, because default free plan is 10k records, 100k ops; default OSS is 50k / 100k and more needs approval but is definitely possible. Docsearch is also always free for OSS

Thank you for taking the time to work on a PR for Awesome-Open-Source-Supporters!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the guidelines: ``[Company Name](link) `tag` - description``
- [x] Your additions are ordered alphabetically.
- [x] Your additions are commercial software that offer their services for free to Open Source projects.
- [x] Your additions contain any relevant tags: `requires-approval`
- [x] You have searched the repository for any relevant issues or PRs.
- [x] Any category you are creating has the minimum requirement of 2 items.
