### PR TITLE
Add Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ A curated list of awesome companies that offer their tools and services for free
 - [Helpmonks](https://helpmonks.com/) `requires-approval` - Collaborative team email inboxes.
 - [Libraries.io](https://libraries.io/) - Open source discovery service.
 - [Mailtrap](https://mailtrap.io/) `requires-approval` - Fake SMTP testing server.
+- [Netlify](https://www.netlify.com) - Hosting for static sites.
 - [Sourcegraph](https://sourcegraph.com/) - Smart source code transparency.
 - [Siteleaf](https://www.siteleaf.com/) - CMS for static sites.
 - [Transloadit](https://transloadit.com/) `requires-approval` - API for file uploading & encoding.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ A curated list of awesome companies that offer their tools and services for free
 - [Helpmonks](https://helpmonks.com/) `requires-approval` - Collaborative team email inboxes.
 - [Libraries.io](https://libraries.io/) - Open source discovery service.
 - [Mailtrap](https://mailtrap.io/) `requires-approval` - Fake SMTP testing server.
-- [Netlify](https://www.netlify.com) - Hosting for static sites.
+- [Netlify](https://www.netlify.com) `requires-approval` - Hosting for static sites.
 - [Sourcegraph](https://sourcegraph.com/) - Smart source code transparency.
 - [Siteleaf](https://www.siteleaf.com/) - CMS for static sites.
 - [Transloadit](https://transloadit.com/) `requires-approval` - API for file uploading & encoding.


### PR DESCRIPTION
Hej, I would like to add [Netlify](https://www.netlify.com) to the list.
See <https://www.netlify.com/open-source/#mooseheads> for details about the Open Source activities. 

In my experience they don’t want any type of approval and are super flexible. I contacted them because we wanted to move <http://yeoman.io/> from GitHub pages to Netlify but we need the »team feature« which isn’t for free by default for Open Source projects. I explained why we need it, and they enabled it for free 💖  

Cheers, Michael

>Thank you for taking the time to work on a PR for Awesome-Open-Source-Supporters!
>
>To ensure your PR is dealt with swiftly please check the following:
>
>- [x] Your submissions are formatted according to the guidelines: ``[Company Name](link) `tag` - description``
>- [x] Your additions are ordered alphabetically.
>- [x] Your additions are commercial software that offer their services for free to Open Source projects.
>- [x] Your additions contain any relevant tags: `requires-approval`
>- [x] You have searched the repository for any relevant issues or PRs.
>- [x] Any category you are creating has the minimum requirement of 2 items.
