### PR TITLE
Create Chat category and include Zulip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A curated list of awesome companies that offer their tools and services for free
 ## Documentation
 
 - [GitBook](https://www.gitbook.com/) - Collaborative application documentation.
+- [Read the Docs](https://readthedocs.com/) - Documentation hosting platform.
 
 ## Exception Reporting
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ A curated list of awesome companies that offer their tools and services for free
 - [Version Control](#version-control)
 - [Miscellaneous](#miscellaneous)
 
+## Chat
+- [Zulip](https://zulip.com) `requires-approval` - Chat for distributed teams.
+
 ## Code Coverage
 
 - [Codecov](https://codecov.io/) - Test coverage monitoring & alerting.


### PR DESCRIPTION
Disclaimer: I work at Zulip.

Zulip's paid plan, "Zulip Standard", is free for open source projects.

Some notes

* I am adding the Chat category as the first section because of Alphabetical order.

* I personally can't think of any leading chat products that offers their Premium plan for free for Open Source projects.
	* Slack - Don't offer paid plans for Free
	* Mattermost - Has no hosting service.
	* Rocket.Chat - Offers plan at special rates (https://rocket.chat/concession)
	* Discord, Spectrum, Gitter etc are free, but they are free for all users and not only for open source projects.

* Activating Zulip Standard for open source projects at the moment requires emailing Zulip for activation. But we are moving to a new model in the coming months where organizations can mark themselves as "open source" during organization creation and they would be upgraded immediately to Zulip Standard. We do the verification later whether they are actually an open-source project.

* More details in https://zulip.com/plans/ and https://zulip.com/for/open-source/

----

Also included Read the Docs. Read the Docs is free for open source but now offers commercial plans for business.
https://readthedocs.com/pricing/
